### PR TITLE
support v1beta1 tekton resources

### DIFF
--- a/internal/handlers/script.go
+++ b/internal/handlers/script.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cezarguimaraes/tkn-dash/internal/syntax"
 	"github.com/cezarguimaraes/tkn-dash/internal/tekton"
 	"github.com/labstack/echo/v4"
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
 func StepScript(chromaStyle string) echo.HandlerFunc {
@@ -17,7 +17,7 @@ func StepScript(chromaStyle string) echo.HandlerFunc {
 			return err
 		}
 
-		var foundStep pipelinev1.Step
+		var foundStep pipelinev1beta1.Step
 		for _, step := range td.TaskRun.Status.TaskSpec.Steps {
 			if step.Name == td.Step {
 				foundStep = step

--- a/internal/loader/local.go
+++ b/internal/loader/local.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/cezarguimaraes/tkn-dash/pkg/cache"
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -16,9 +16,9 @@ import (
 func loadFile(path, kind string) (cache.Store, error) {
 	switch kind {
 	case "taskrun":
-		return cache.FromFile[*pipelinev1.TaskRun](path)
+		return cache.FromFile[*pipelinev1beta1.TaskRun](path)
 	case "pipelinerun":
-		return cache.FromFile[*pipelinev1.PipelineRun](path)
+		return cache.FromFile[*pipelinev1beta1.PipelineRun](path)
 	default:
 		return nil, fmt.Errorf("unknown kind: %q", kind)
 	}

--- a/internal/tekton/bind.go
+++ b/internal/tekton/bind.go
@@ -3,7 +3,7 @@ package tekton
 import (
 	"golang.org/x/exp/slices"
 
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
 type TemplateData struct {
@@ -17,16 +17,16 @@ type TemplateData struct {
 	Resource string
 
 	// PipelineRun is resolved from the :pipelineRun url param
-	PipelineRun *pipelinev1.PipelineRun
+	PipelineRun *pipelinev1beta1.PipelineRun
 
 	// TaskRun is resolved from the :taskRun url param
-	TaskRun *pipelinev1.TaskRun
+	TaskRun *pipelinev1beta1.TaskRun
 
 	// TaskRuns is the list of taskRuns that should be rendered
 	// in the middle "step view". It is either a list containing
 	// a single taskRun in taskRun view, or the list of taskRuns
 	// pertaining to a pipelineRUn
-	TaskRuns []*pipelinev1.TaskRun
+	TaskRuns []*pipelinev1beta1.TaskRun
 
 	// Step is the name of the step resolved from the :step url param
 	Step string
@@ -85,7 +85,7 @@ func (c *Context) BindTemplateData(td *TemplateData) error {
 			td.Step = c.QueryParam(pn)
 		case "task":
 			td.TaskRun = c.GetTaskRun(td.Namespace, c.QueryParam(pn))
-			td.TaskRuns = []*pipelinev1.TaskRun{td.TaskRun}
+			td.TaskRuns = []*pipelinev1beta1.TaskRun{td.TaskRun}
 		}
 	}
 

--- a/internal/tekton/context.go
+++ b/internal/tekton/context.go
@@ -3,7 +3,7 @@ package tekton
 import (
 	"github.com/cezarguimaraes/tkn-dash/pkg/cache"
 	"github.com/labstack/echo/v4"
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
 type Context struct {
@@ -40,28 +40,28 @@ func (c *Context) GetStoreFor(resource string) cache.Store {
 	return nil
 }
 
-func (c *Context) GetTaskRun(namespace, name string) *pipelinev1.TaskRun {
+func (c *Context) GetTaskRun(namespace, name string) *pipelinev1beta1.TaskRun {
 	tr, err := c.tr.Get(namespace, name)
 	if err != nil {
 		return nil
 	}
-	return tr.(*pipelinev1.TaskRun)
+	return tr.(*pipelinev1beta1.TaskRun)
 }
 
-func (c *Context) GetPipelineRun(namespace, name string) *pipelinev1.PipelineRun {
+func (c *Context) GetPipelineRun(namespace, name string) *pipelinev1beta1.PipelineRun {
 	pr, err := c.pr.Get(namespace, name)
 	if err != nil {
 		return nil
 	}
-	return pr.(*pipelinev1.PipelineRun)
+	return pr.(*pipelinev1beta1.PipelineRun)
 }
 
-func (c *Context) GetPipelineTaskRuns(namespace, name string) []*pipelinev1.TaskRun {
+func (c *Context) GetPipelineTaskRuns(namespace, name string) []*pipelinev1beta1.TaskRun {
 	pr := c.GetPipelineRun(namespace, name)
 	if pr == nil {
 		return nil
 	}
-	var trs []*pipelinev1.TaskRun
+	var trs []*pipelinev1beta1.TaskRun
 	for _, cr := range pr.Status.ChildReferences {
 		trs = append(trs, c.GetTaskRun(namespace, cr.Name))
 	}

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	tektoncs "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -236,14 +236,14 @@ func initializeStores(
 	tcs *tektoncs.Clientset,
 ) (trs cache.Store, prs cache.Store, stopFn func()) {
 	trInformer, trStopFn := cache.NewSharedInformerCache(
-		tcs.TektonV1().RESTClient(),
+		tcs.TektonV1beta1().RESTClient(),
 		"taskruns",
-		&pipelinev1.TaskRun{},
+		&pipelinev1beta1.TaskRun{},
 	)
 	prInformer, prStopFn := cache.NewSharedInformerCache(
-		tcs.TektonV1().RESTClient(),
+		tcs.TektonV1beta1().RESTClient(),
 		"pipelineruns",
-		&pipelinev1.PipelineRun{},
+		&pipelinev1beta1.PipelineRun{},
 	)
 
 	stopFn = func() {


### PR DESCRIPTION
it seems we don't currently use any field on `v1` resources that isn't available in the `v1beta1` API, so in order for the dashboard to work with pre `v1` tekton versions, we can default to use `v1beta` resources for now.